### PR TITLE
fix: missing initial value for Array.reduce()

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,7 +135,7 @@ exports.handler = (event, context, callback) => {
 
         let projectedSize = recs.filter(rec => rec.result !== 'ProcessingFailed')
                               .map(r => r.recordId.length + r.data.length)
-                              .reduce((a, b) => a + b);
+                              .reduce((a, b) => a + b, 0);
         // 4000000 instead of 6291456 to leave ample headroom for the stuff we didn't account for
         for (let idx = 0; idx < event.records.length && projectedSize > 4000000; idx += 1) {
             const rec = result.records[idx];


### PR DESCRIPTION
Hi, this is a very useful blueprint, I love it. Thanks for your efforts.

I have faced an issue that Array.Reduce() throws an error due to the missing initial value.
This PR might be helpful, please have a look 😄 